### PR TITLE
additional attributes in GLRD entries, better export/import and nicer fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ patch-1592.1        	1592.1              	patch               	ec945aa          
       },
       "github": {
         "release": "https://github.com/gardenlinux/gardenlinux/releases/tag/1592.1"
+      },
+      "attributes": {
+        "source_repo": false
       }
     }
   ]
@@ -375,6 +378,9 @@ This will generate/update a release from JSON data and upload it to the default 
       },
       "github": {
         "release": "https://github.com/gardenlinux/gardenlinux/releases/tag/1592.1"
+      },
+      "attributes": {
+        "source_repo": false
       }
     }
   ]
@@ -403,6 +409,8 @@ releases:
       commit_short: ec945aa
     github:
       release: https://github.com/gardenlinux/gardenlinux/releases/tag/1592.1
+    attributes:
+      source_repo: false
 
 ❯ glrd-manage --input --input-file releases-input.yaml
 ```
@@ -485,6 +493,8 @@ The Garden Linux Release Database (GLRD) uses structured JSON schemas to represe
   - **`commit_short`**: The short git commit hash (first 7 characters).
 - **`github`**:
   - **`release`**: The URL to the GitHub release page.
+- **`attributes`**: An object that does contain additional metadata about the release.
+  - **`source_repo`**: A boolean indicating whether the release has debian source repoitories (default: true).
 
 ### Nightly Releases
 
@@ -504,6 +514,8 @@ The Garden Linux Release Database (GLRD) uses structured JSON schemas to represe
 - **`git`**:
   - **`commit`**: The full git commit hash associated with the release.
   - **`commit_short`**: The short git commit hash.
+- **`attributes`**: An object that does contain additional metadata about the release.
+  - **`source_repo`**: A boolean indicating whether the release has debian source repoitories (default: true).
 
 ### Development Releases
 
@@ -523,6 +535,8 @@ The Garden Linux Release Database (GLRD) uses structured JSON schemas to represe
 - **`git`**:
   - **`commit`**: The full git commit hash associated with the release.
   - **`commit_short`**: The short git commit hash.
+- **`attributes`**: An object that does contain additional metadata about the release.
+  - **`source_repo`**: A boolean indicating whether the release has debian source repoitories (default: true).
 
 ### Next Release
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,21 @@ The `glrd-manage` script is used to generate release data for Garden Linux. It c
 
 ```
 ❯ glrd-manage --help
-usage: glrd-manage [-h] [--delete DELETE] [--create-initial-releases CREATE_INITIAL_RELEASES] [--create CREATE] [--version VERSION] [--commit COMMIT] [--lifecycle-released-isodatetime LIFECYCLE_RELEASED_ISODATETIME] [--lifecycle-extended-isodatetime LIFECYCLE_EXTENDED_ISODATETIME] [--lifecycle-eol-isodatetime LIFECYCLE_EOL_ISODATETIME] [--no-query] [--input-stdin] [--input] [--input-file INPUT_FILE] [--output-file-prefix OUTPUT_FILE_PREFIX]
-                   [--output-format {yaml,json}] [--no-output-split] [--s3-bucket-name S3_BUCKET_NAME] [--s3-bucket-prefix S3_BUCKET_PREFIX] [--s3-bucket-region S3_BUCKET_REGION] [--s3-create-bucket] [--s3-update] [--log-level {ERROR,WARNING,INFO,DEBUG}]
+usage: glrd-manage [-h] [--delete DELETE]
+                   [--create-initial-releases CREATE_INITIAL_RELEASES]
+                   [--create CREATE] [--version VERSION] [--commit COMMIT]
+                   [--lifecycle-released-isodatetime LIFECYCLE_RELEASED_ISODATETIME]
+                   [--lifecycle-extended-isodatetime LIFECYCLE_EXTENDED_ISODATETIME]
+                   [--lifecycle-eol-isodatetime LIFECYCLE_EOL_ISODATETIME]
+                   [--no-query] [--input-stdin] [--input]
+                   [--input-file INPUT_FILE]
+                   [--output-file-prefix OUTPUT_FILE_PREFIX]
+                   [--output-format {yaml,json}] [--no-output-split]
+                   [--s3-bucket-name S3_BUCKET_NAME]
+                   [--s3-bucket-prefix S3_BUCKET_PREFIX]
+                   [--s3-bucket-region S3_BUCKET_REGION] [--s3-create-bucket]
+                   [--s3-update] [--log-level {ERROR,WARNING,INFO,DEBUG}]
+                   [--output-all] [--input-all]                   
 
 Create or delete Garden Linux releases in the GLRD.
 
@@ -307,6 +320,8 @@ options:
   --s3-create-bucket    Create an S3 bucket.
   --s3-update           Update (merge) the generated files with S3.
   --log-level {ERROR,WARNING,INFO,DEBUG}
+  --output-all          Download and write all release files found in S3 to local disk.
+  --input-all           Upload all local release files to S3.
 ```
 
 ### Testing release creation

--- a/glrd/manage.py
+++ b/glrd/manage.py
@@ -140,6 +140,16 @@ SCHEMAS = {
                 "type": "object",
                 "properties": {"release": {"type": "string", "format": "uri"}},
                 "required": ["release"]
+            },
+            "attributes": {
+                "type": "object",
+                "properties": {
+                    "source_repo": {
+                        "type": "boolean",
+                        "default": True
+                    }
+                },
+                "required": ["source_repo"]
             }
         },
         "required": ["name", "type", "version", "lifecycle", "git", "github"]
@@ -171,6 +181,16 @@ SCHEMAS = {
                     "commit_short": {"type": "string", "pattern": "^[0-9a-f]{7,8}$"}
                 },
                 "required": ["commit", "commit_short"]
+            },
+            "attributes": {
+                "type": "object",
+                "properties": {
+                    "source_repo": {
+                        "type": "boolean",
+                        "default": True
+                    }
+                },
+                "required": ["source_repo"]
             }
         },
         "required": ["name", "type", "version", "lifecycle", "git"]
@@ -202,6 +222,16 @@ SCHEMAS = {
                     "commit_short": {"type": "string", "pattern": "^[0-9a-f]{7,8}$"}
                 },
                 "required": ["commit", "commit_short"]
+            },
+            "attributes": {
+                "type": "object",
+                "properties": {
+                    "source_repo": {
+                        "type": "boolean",
+                        "default": True
+                    }
+                },
+                "required": ["source_repo"]
             }
         },
         "required": ["name", "type", "version", "lifecycle", "git"]
@@ -564,6 +594,8 @@ def create_single_release(release_type, args, existing_releases):
         release['git'] = {}
         release['git']['commit'] = commit
         release['git']['commit_short'] = commit_short
+        release['attributes'] = {}
+        release['attributes']['source_repo'] = args.source_repo if 'source_repo' in args else True
     elif release_type == "next":
         release['name'] = f"{release_type}"
         release['lifecycle']['extended'] = {}

--- a/glrd/query.py
+++ b/glrd/query.py
@@ -6,6 +6,7 @@ import os
 import yaml
 import tabulate
 from glrd.util import *
+import sys
 
 DEFAULTS = dict(DEFAULTS, **{
     'POSSIBLE_FIELDS_MAP': {
@@ -70,6 +71,13 @@ def find_latest_release(releases):
 def format_output(args, releases, output_format, fields=None, no_header=False):
     """Format release data for output."""
     selected_fields = fields.split(',') if fields else DEFAULTS['DEFAULT_QUERY_FIELDS'].split(',')
+    
+    invalid_fields = [field for field in selected_fields if field not in DEFAULTS['POSSIBLE_FIELDS_MAP']]
+    if invalid_fields:
+        print(f"Error: Invalid field(s): {', '.join(invalid_fields)}", file=sys.stderr)
+        print(f"Available fields: {', '.join(DEFAULTS['POSSIBLE_FIELDS_MAP'].keys())}", file=sys.stderr)
+        sys.exit(1)
+    
     rows = [
         [DEFAULTS['POSSIBLE_FIELDS_MAP'][field](r) for field in selected_fields]
         for r in releases

--- a/glrd/query.py
+++ b/glrd/query.py
@@ -76,7 +76,7 @@ def format_output(args, releases, output_format, fields=None, no_header=False):
     ]
     
     # Create headers based on selected fields
-    headers = [field for field in selected_fields]
+    headers = [field for field in selected_fields] if not no_header else ()
 
     if output_format == 'shell':
         print(tabulate.tabulate(rows, headers, tablefmt="plain"))

--- a/glrd/query.py
+++ b/glrd/query.py
@@ -17,7 +17,8 @@ DEFAULTS = dict(DEFAULTS, **{
         "ReleaseDate": lambda r: r['lifecycle']['released'].get('isodate', 'N/A'),
         "ReleaseTime": lambda r: timestamp_to_isotime(r['lifecycle']['released'].get('timestamp')),
         "ExtendedMaintenance": lambda r: get_extended_maintenance(r),
-        "EndOfMaintenance": lambda r: r['lifecycle'].get('eol', {}).get('isodate', 'N/A')
+        "EndOfMaintenance": lambda r: r['lifecycle'].get('eol', {}).get('isodate', 'N/A'),
+        "AttributesSourceRepo": lambda r: str(r.get('attributes', {}).get('source_repo', 'N/A'))  # Convert boolean to string
     }
 })
 

--- a/glrd/util.py
+++ b/glrd/util.py
@@ -6,6 +6,7 @@ import pytz
 from datetime import datetime
 
 DEFAULTS = {
+    'DEFAULT_QUERY_FIELDS': 'Name,Version,Type,GitCommitShort,ReleaseDate,ReleaseTime,ExtendedMaintenance,EndOfMaintenance',
     'DEFAULT_QUERY_INPUT_FORMAT': 'json',
     'DEFAULT_QUERY_INPUT_FILE_PREFIX': 'releases',
     'DEFAULT_QUERY_INPUT_TYPE': 'url',


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to maintain additional attributes in GLRD entries. The first use case is if a release has source repositores available (#1).
Also this introduces two new flags for `glrd-manage` that make it easier to do exports, do mass changes, and do imports off all entries.

```
  --output-all          Download and write all release files found in S3 to
                        local disk
  --input-all           Upload all local release files to S3
```

To have nicer possibilities to run `glrd --filter` without spaces in column names, we have a breaking change in how the field keys are accessed. This is backward compatible as the schema does not change and the old field keys will still work for the v1 release.

**Which issue(s) this PR fixes**:
Fixes #1 


