### PR TITLE
Versioning with poetry

### DIFF
--- a/.github/workflows/image-dev.yml
+++ b/.github/workflows/image-dev.yml
@@ -23,6 +23,8 @@ jobs:
         arch: [ amd64, arm64 ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed for poetry-dynamic-versioning
       - uses: ./.github/actions/setup
       - name: podman login
         run: |

--- a/.github/workflows/image-dev.yml
+++ b/.github/workflows/image-dev.yml
@@ -30,7 +30,7 @@ jobs:
       - name: podman build
         run: |
           podman build --platform linux/${{ matrix.arch }} -t glrd .
-      - name: podman build
+      - name: podman save
         run: |
           podman save --format oci-archive glrd >/tmp/${{ matrix.arch }}-oci.tar
       - name: upload build-${{ matrix.arch }}

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -17,6 +17,8 @@ jobs:
         arch: [ amd64, arm64 ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Needed for poetry-dynamic-versioning
       - uses: ./.github/actions/setup
       - name: podman login
         run: |

--- a/.github/workflows/image-release.yml
+++ b/.github/workflows/image-release.yml
@@ -69,3 +69,18 @@ jobs:
           version=${{ github.ref_name }}
           podman manifest push ghcr.io/${{ github.repository }} docker://ghcr.io/${{ github.repository }}:latest
           podman manifest push ghcr.io/${{ github.repository }} docker://ghcr.io/${{ github.repository }}:${version}
+
+  release:
+    name: Github Release
+    runs-on: 'ubuntu-latest'
+    needs: ['push']
+    steps:
+      - name: Create Github Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${GITHUB_REPOSITORY#*/} ${tag#v}" \
+              --generate-notes

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,4 @@
-# overwrite with a stable gardenlinux version
-ARG GL_VERSION=latest
+ARG GL_VERSION=nightly
 ARG GL_BASE=ghcr.io/gardenlinux/gardenlinux:${GL_VERSION}
 
 FROM ${GL_BASE}
@@ -8,38 +7,32 @@ LABEL org.opencontainers.image.source=https://github.com/gardenlinux/glrd
 LABEL org.opencontainers.image.description="Garden Linux Release Database"
 LABEL org.opencontainers.image.licenses=MIT
 
-ENV PYTHON=python3.12
-
+ENV PYTHON=python3.13
+ENV POETRY_HOME=/opt/poetry
 ENV DEBIAN_FRONTEND noninteractive
-ENV SHELL /bin/bash
-ENV PYTHONPATH /gardenlinux/bin:/gardenlinux/ci:/gardenlinux/ci/glci:/gardenlinux/tests:/gardenlinux/features
+ENV PATH=${POETRY_HOME}/bin:/app/.venv/bin:$PATH
 
-# install some basic tools
+# install runtime dependencies and GitHub CLI
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-       # python from GL repos, all python packages are supposed to come from pip
        ${PYTHON}-venv \
-       # lib${PYTHON}-dev \
-       wget \
+       git \
+       curl \
     && mkdir -p -m 755 /etc/apt/keyrings \
-    && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
     && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update \
     && apt-get install -y --no-install-recommends gh \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Prepare virtual environment
-# We need a virtual env to install packages via pip, and not via apt.
-# See: https://peps.python.org/pep-0668/
-ENV VIRTUAL_ENV_PARENT=/opt/python-test-env
-ENV VIRTUAL_ENV="$VIRTUAL_ENV_PARENT/.venv"
-RUN ${PYTHON} -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# Install poetry
+RUN ${PYTHON} -m venv ${POETRY_HOME} \
+    && pip install poetry poetry-dynamic-versioning && poetry config virtualenvs.in-project true
 
-COPY . /usr/local/glrd
-# Do not use --system, we want the pip from the virtual env
-# RUN cd "$VIRTUAL_ENV_PARENT" && pip install -r requirements.txt
-RUN pip install -e /usr/local/glrd
-WORKDIR /usr/local/glrd
+# Set up project
+WORKDIR /app
+COPY . .
+RUN poetry install --no-interaction
+
 ENTRYPOINT ["/usr/bin/sh", "-c"]

--- a/glrd/manage.py
+++ b/glrd/manage.py
@@ -1312,6 +1312,7 @@ def parse_arguments():
                        help="Download and write all release files found in S3 to local disk")
     parser.add_argument('--input-all', action='store_true',
                        help="Upload all local release files to S3")
+    parser.add_argument('-V', action='version', version=f'%(prog)s {get_version()}')
 
     args = parser.parse_args()
 

--- a/glrd/query.py
+++ b/glrd/query.py
@@ -375,6 +375,8 @@ def parse_arguments():
     parser.add_argument('--no-header', action='store_true', 
                        help="Omit the header in shell output.")
     
+    parser.add_argument('-V', action='version', version=f'%(prog)s {get_version()}')
+    
     return parser.parse_args()
 
 def get_platform_from_flavor(flavor):
@@ -507,6 +509,8 @@ def process_query(args):
     format_output(args, releases, args.output_format, args.fields, args.no_header)
 
 def main():
+    parser = argparse.ArgumentParser(description='Garden Linux Release Database Query Tool')
+    parser.add_argument('--version', action='version', version=f'%(prog)s {get_version()}')
     args = parse_arguments()
 
     process_query(args)

--- a/glrd/update.py
+++ b/glrd/update.py
@@ -10,7 +10,7 @@ from glrd.manage import (
     download_all_s3_files,
     upload_all_local_files
 )
-from glrd.util import DEFAULTS, ERROR_CODES
+from glrd.util import *
 
 from python_gardenlinux_lib.flavors.parse_flavors import *
 from python_gardenlinux_lib.s3.s3 import *
@@ -45,6 +45,8 @@ def parse_arguments():
     
     parser.add_argument('--version', type=str,
                       help="Only process releases with this version (format: major.minor)")
+    
+    parser.add_argument('-V', action='version', version=f'%(prog)s {get_version()}')
     
     args = parser.parse_args()
     

--- a/glrd/util.py
+++ b/glrd/util.py
@@ -1,12 +1,14 @@
+import json
+import logging
 import os
 import re
 import signal
 import sys
-import pytz
-import json
-import yaml
-import logging
 from datetime import datetime
+
+import importlib.metadata
+import pytz
+import yaml
 
 ERROR_CODES = {
     "validation_error": 1,
@@ -73,6 +75,9 @@ DEFAULTS = {
         'vmware': 'ova',
     }
 }
+
+def get_version():
+    return importlib.metadata.version('glrd') 
 
 def extract_version_data(tag_name):
     """Extract major and minor version numbers from a tag."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [project]
+name = "glrd"
 dynamic = ["version"]
 
 [tool.poetry]
@@ -24,6 +25,15 @@ python-gardenlinux-lib = { git = "https://github.com/gardenlinux/python-gardenli
 
 [tool.poetry-dynamic-versioning]
 enable = true
+vcs = "git"
+style = "pep440"
+pattern = '''(?x)
+    v(?P<base>\d+\.\d+\.\d+)
+'''
+strict = true
+dirty = true
+metadata = true
+tagged-metadata = false
 
 [tool.poetry.scripts]
 glrd-update = "glrd.update:main"


### PR DESCRIPTION
**What this PR does / why we need it**:

After the switch to poetry in #3  the versioning is still not implemented correctly.
This does:

- adapt `Containerfile` for poetry
- set version based on tag, e.g. `v3.0.0` + `v3`
- version is available in python programs via `-V` flag.
- auto generate github release notes