### PR TITLE
force podman install and configuration on non x86_64

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
     - name: install podman
       shell: bash
       run: |
-        if ! command -v podman; then
+        if ! command -v podman || ! $(uname -m) == "x86_64"; then
           sudo env DEBIAN_FRONTEND=noninteractive apt-get update
           sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends podman uidmap slirp4netns dbus-user-session
           id="$(id -u)"


### PR DESCRIPTION
**What this PR does / why we need it**:

recent arm64 github runners seem to have podman installed but not configured correctly