### PR TITLE
Add Lima Platform to fetch qcow2 image properly

### DIFF
--- a/glrd/util.py
+++ b/glrd/util.py
@@ -68,6 +68,7 @@ DEFAULTS = {
         "openstack": "qcow2",
         "openstackbaremetal": "qcow2",
         "vmware": "ova",
+        "lima": "qcow2",
     },
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Lima platform to fetch qcow2 image
**Which issue(s) this PR fixes**:
Fixes #
Currently it fetched raw file for lima, this corrects the image path to fetch qcow2 file
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
