### PR TITLE
chore: rename docs-ng to docs and fix netlify links

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,12 +2,12 @@ name: Documentation Quality Check
 
 on:
   pull_request:
-    branches: [main, docs-ng]
+    branches: [main]
     types: [opened, synchronize, reopened, closed]
     paths:
       - 'docs/**'
   push:
-    branches: [main, docs-ng]
+    branches: [main]
     paths:
       - 'docs/**'
 
@@ -15,14 +15,14 @@ jobs:
   docs-checks:
     # Skip checks on closed PRs (only need the notification)
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
-    uses: gardenlinux/docs-ng/.github/workflows/docs-checks.yml@main
+    uses: gardenlinux/docs/.github/workflows/docs-checks.yml@main
     with:
       override-repo: ${{ github.event.repository.name }}
       override-ref: ${{ github.head_ref || github.ref_name }}
       override-commit: ${{ github.event.pull_request.head.sha || github.sha }}
 
-  notify-docs-ng:
-    name: Notify docs-ng
+  notify-docs:
+    name: Notify docs
     needs: [docs-checks]
     runs-on: ubuntu-24.04
     # Only notify for PR events (not push events which lack PR context)
@@ -41,9 +41,9 @@ jobs:
         with:
           app-id: ${{ secrets.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
-          repositories: docs-ng
+          repositories: docs
 
-      - name: Send repository dispatch to docs-ng
+      - name: Send repository dispatch to docs
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -59,7 +59,7 @@ jobs:
 
             await github.rest.repos.createDispatchEvent({
               owner: 'gardenlinux',
-              repo: 'docs-ng',
+              repo: 'docs',
               event_type: 'docs-pr',
               client_payload: {
                 repo: '${{ github.event.repository.name }}',
@@ -71,4 +71,4 @@ jobs:
                 event: isMergedPR ? 'merged' : 'pr_success'
               }
             });
-            core.info('Repository dispatch sent to docs-ng');
+            core.info('Repository dispatch sent to docs');

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ information for the Garden Linux distribution.
 ## Documentation
 
 To find out how GLRD works, our
-[documentation hub](https://gardenlinux-docs.netlify.app/) contains a
-[detailed reference document](https://gardenlinux-docs.netlify.app/reference/supporting_tools/glrd.html).
+[documentation hub](https://docs.gardenlinux.org/) contains a
+[detailed reference document](https://docs.gardenlinux.org/reference/supporting_tools/glrd.html).
 
 In addition refer to our
-[release lifecycle document](https://gardenlinux-docs.netlify.app/reference/releases/release-lifecycle.html)
+[release lifecycle document](https://docs.gardenlinux.org/reference/releases/release-lifecycle.html)
 to learn how our releases work.
 
 ## Community
@@ -35,7 +35,7 @@ https://lists.neonephos.org/g/gardenlinux-security-embargo
 We welcome your contributions to Gardenlinux or any supporting projects.
 
 To find our more, visit our
-[Contributor Documentation](https://gardenlinux-docs.netlify.app/contributing).
+[Contributor Documentation](https://docs.gardenlinux.org/contributing).
 
 ## Licensing
 


### PR DESCRIPTION
**What this PR does / why we need it**:

chore: rename docs-ng to docs and fix netlify links
